### PR TITLE
Specify tags to be removed during anonymization.

### DIFF
--- a/lib/dicom/anonymizer.rb
+++ b/lib/dicom/anonymizer.rb
@@ -236,6 +236,12 @@ module DICOM
               replace_uids(obj) if @uid
               # Remove private tags?
               obj.remove_private if @remove_private
+              
+              # Remove Tags marked for removal
+              @delete_tags.each_index do |j|
+                obj.remove(@delete_tags[j]) if obj.exists?(@delete_tags[j])
+              end
+              
               # Write DICOM file:
               obj.write(@write_paths[i])
               if obj.written?
@@ -365,6 +371,22 @@ module DICOM
         @values.delete_at(pos)
         @enumerations.delete_at(pos)
       end
+    end
+    
+    # Compeletely deletes a tag from the file
+    #
+    # === Parameters
+    #
+    # * <tt>tag</tt> -- String. A data element tag.
+    #
+    # === Examples
+    #
+    #   a.delete_tag("0010,0010")
+    #
+    def delete_tag(tag)
+      raise ArgumentError, "Expected String, got #{tag.class}." unless tag.is_a?(String)
+      raise ArgumentError, "Expected a valid tag of format 'GGGG,EEEE', got #{tag}." unless tag.tag?
+      @delete_tags.push(tag) if not @delete_tags.include?(tag)
     end
 
     # Sets the anonymization settings for the specified tag. If the tag is already present in the list
@@ -641,6 +663,10 @@ module DICOM
       @tags = data[0]
       @values = data[1]
       @enumerations = data[2]
+      
+      # Tags to be removed completely during anonymization
+      @delete_tags = [
+      ]
     end
 
     # Writes an identity file, which allows reidentification of DICOM files that have been anonymized
@@ -667,6 +693,5 @@ module DICOM
         end
       end
     end
-
   end
 end

--- a/spec/dicom/anonymizer_spec.rb
+++ b/spec/dicom/anonymizer_spec.rb
@@ -379,6 +379,31 @@ module DICOM
       end
 
     end
+    
+    describe "#delete_tag" do
+
+      it "should raise an ArgumentError when a non-string is passed as an argument" do
+        a = Anonymizer.new
+        expect {a.delete_tag(42)}.to raise_error(ArgumentError)
+      end
+
+      it "should raise an ArgumentError when a non-tag string is passed as an argument" do
+        a = Anonymizer.new
+        expect {a.delete_tag("asdf,asdf")}.to raise_error(ArgumentError)
+      end
+
+      it "should remove tag marked for deletion during anonymization" do
+        a = Anonymizer.new
+        obj = DObject.read(@anon3)
+        obj.exists?("0010,0010").should be_true
+        a.add_folder(@anon_other)
+        a.delete_tag("0010,0010")
+        a.execute
+        obj = DObject.read(@anon3)
+        obj.exists?("0010,0010").should be_false
+      end
+
+    end
 
 
     describe "#set_tag" do


### PR DESCRIPTION
Chris,

This is a minor change that adds a function to add a tag to be completely removed during anonymization. Originally I had the list populated with a bunch of default tags that should be removed, but this approach seemed more flexible. I can provide you with a list that I am currently using, but I have found there are usually quite a few tags that would not make sense to be in an anonymized file. Some tags give away the patient's sex just by being present in the file.

Jeff
