### PR TITLE
Adding host as parameter to cover the problem that at least on Windows 7...

### DIFF
--- a/lib/dicom/link.rb
+++ b/lib/dicom/link.rb
@@ -57,7 +57,7 @@ module DICOM
       segments = receive_single_transmission
       info = segments.first
       if info[:pdu] != PDU_RELEASE_REQUEST
-        # For some reason we didnt get our expected release request. Determine why:
+        # For some reason we didn't get our expected release request. Determine why:
         if info[:valid]
           logger.error("Unexpected message type received (PDU: #{info[:pdu]}). Expected a release request. Closing the connection.")
           handle_abort(false)


### PR DESCRIPTION
... 64 the Ruby TCPServer binds against a IPV6 interface. By defining explicit an interface this could be solved. Correcting some typos.
