### PR TITLE
stop receiving tranmission data when timeout

### DIFF
--- a/lib/dicom/link.rb
+++ b/lib/dicom/link.rb
@@ -1426,6 +1426,7 @@ module DICOM
       response = IO.select([@session], nil, nil, @timeout)
       if response.nil?
         logger.error("No answer was received within the specified timeout period. Aborting.")
+        stop_receiving
       else
         data = @session.recv(@max_receive_size)
       end


### PR DESCRIPTION
stop receiving in receive_transmission_data when "No answer was received within the specified timeout period."

Fired up a fresh DServer, did a find_images against it and it constantly looped trying to get a response from the server.  This fixes that issue.
