### PR TITLE
DClient: fix transfers of large studies over slow links from servers tha...

### DIFF
--- a/lib/dicom/d_client.rb
+++ b/lib/dicom/d_client.rb
@@ -624,7 +624,7 @@ module DICOM
           @link.build_data_fragment(@data_elements, presentation_context_id)
           @link.transmit
           # Receive confirmation response:
-          segments = @link.receive_single_transmission
+          segments = @link.receive_multiple_transmissions
           process_returned_data(segments)
         end
         # Close the DICOM link:


### PR DESCRIPTION
DClient: fix transfers of large studies over slow links from servers that require the Q&R connection to remain open until the CMOVE ends.

I'm not sure how to write a test for this that doesn't require access to a server that exhibits this behaviour.
