### PR TITLE
Change Fixnum to Integer

### DIFF
--- a/lib/dicom/anonymizer.rb
+++ b/lib/dicom/anonymizer.rb
@@ -50,7 +50,7 @@ module DICOM
     # @option options [Boolean] :delete_private toggles whether private elements are to be deleted
     # @option options [TrueClass, Digest::Class] :encryption if set as true, the default hash function (MD5) will be used for representing DICOM values in an audit file. Otherwise a Digest class can be given, e.g. Digest::SHA256
     # @option options [Boolean] :enumeration toggles whether (some) elements get enumerated values (to enable post-anonymization re-identification)
-    # @option options [Fixnum] :logger_level the logger level which is applied to DObject operations during anonymization (defaults to Logger::FATAL)
+    # @option options [Integer] :logger_level the logger level which is applied to DObject operations during anonymization (defaults to Logger::FATAL)
     # @option options [Boolean] :random_file_name toggles whether anonymized files will be given random file names when rewritten (in combination with the :write_path option)
     # @option options [Boolean] :recursive toggles whether to anonymize on all sub-levels of the DICOM object tag hierarchies
     # @option options [Boolean] :uid toggles whether UIDs will be replaced with custom generated UIDs (beware that to preserve UID relations in studies/series, the audit_trail feature must be used)
@@ -210,7 +210,7 @@ module DICOM
     #
     # @note Two objects with the same attributes will have the same hash code.
     #
-    # @return [Fixnum] the object's hash code
+    # @return [Integer] the object's hash code
     #
     def hash
       state.hash
@@ -471,7 +471,7 @@ module DICOM
     # a new enumerated replacement value is found by increasing an index by 1.
     #
     # @param [String, Integer, Float] original the original value of the tag to be anonymized
-    # @param [Fixnum] j the index of this tag in the tag-related instance arrays
+    # @param [Integer] j the index of this tag in the tag-related instance arrays
     # @return [String, Integer, Float] the replacement value which is used for the anonymization of the tag
     #
     def enumerated_value(original, j)

--- a/lib/dicom/d_object.rb
+++ b/lib/dicom/d_object.rb
@@ -238,7 +238,7 @@ module DICOM
     #
     # @note Two objects with the same attributes will have the same hash code.
     #
-    # @return [Fixnum] the object's hash code
+    # @return [Integer] the object's hash code
     #
     def hash
       state.hash

--- a/lib/dicom/element.rb
+++ b/lib/dicom/element.rb
@@ -134,7 +134,7 @@ module DICOM
     #
     # @note Two objects with the same attributes will have the same hash code.
     #
-    # @return [Fixnum] the object's hash code
+    # @return [Integer] the object's hash code
     #
     def hash
       state.hash

--- a/lib/dicom/elemental.rb
+++ b/lib/dicom/elemental.rb
@@ -10,7 +10,7 @@ module DICOM
 
     # The encoded, binary value of the elemental (String).
     attr_reader :bin
-    # The elemental's length (Fixnum).
+    # The elemental's length (Integer).
     attr_reader :length
     # The elemental's name (String).
     attr_reader :name

--- a/lib/dicom/image_item.rb
+++ b/lib/dicom/image_item.rb
@@ -779,7 +779,7 @@ module DICOM
       # Number of bytes used per pixel will determine how to unpack this:
       case depth
       when 8 # (1 byte)
-        template = 'BY' # Byte/Character/Fixnum
+        template = 'BY' # Byte/Character/Integer
       when 16 # (2 bytes)
         if pixel_representation == 1
          template = 'SS' # Signed short

--- a/lib/dicom/item.rb
+++ b/lib/dicom/item.rb
@@ -92,7 +92,7 @@ module DICOM
     #
     # @note Two objects with the same attributes will have the same hash code.
     #
-    # @return [Fixnum] the object's hash code
+    # @return [Integer] the object's hash code
     #
     def hash
       state.hash

--- a/lib/dicom/link.rb
+++ b/lib/dicom/link.rb
@@ -26,8 +26,8 @@ module DICOM
     # * <tt>:ae</tt> -- String. The name of the client (application entity).
     # * <tt>:file_handler</tt> -- A customized FileHandler class to use instead of the default FileHandler.
     # * <tt>:host_ae</tt> -- String. The name of the server (application entity).
-    # * <tt>:max_package_size</tt> -- Fixnum. The maximum allowed size of network packages (in bytes).
-    # * <tt>:timeout</tt> -- Fixnum. The maximum period to wait for an answer before aborting the communication.
+    # * <tt>:max_package_size</tt> -- Integer. The maximum allowed size of network packages (in bytes).
+    # * <tt>:timeout</tt> -- Integer. The maximum period to wait for an answer before aborting the communication.
     #
     def initialize(options={})
       require 'socket'
@@ -1075,7 +1075,7 @@ module DICOM
     # === Parameters
     #
     # * <tt>adress</tt> -- String. The adress (IP) of the remote node.
-    # * <tt>port</tt> -- Fixnum. The network port to be used in the network communication.
+    # * <tt>port</tt> -- Integer. The network port to be used in the network communication.
     #
     def start_session(adress, port)
       @session = TCPSocket.new(adress, port)
@@ -1303,7 +1303,7 @@ module DICOM
     #
     # === Parameters
     #
-    # * <tt>result</tt> -- Fixnum. The result code from an association response.
+    # * <tt>result</tt> -- Integer. The result code from an association response.
     #
     def process_result(result)
       unless result == 0
@@ -1350,7 +1350,7 @@ module DICOM
     #
     # === Parameters
     #
-    # * <tt>status</tt> -- Fixnum. A status code from a command fragment.
+    # * <tt>status</tt> -- Integer. A status code from a command fragment.
     #
     def process_status(status)
       case status
@@ -1397,7 +1397,7 @@ module DICOM
     #
     # === Parameters
     #
-    # * <tt>min_length</tt> -- Fixnum. The minimum possible length of a valid incoming transmission.
+    # * <tt>min_length</tt> -- Integer. The minimum possible length of a valid incoming transmission.
     #
     def receive_transmission(min_length=0)
       data = receive_transmission_data

--- a/lib/dicom/sequence.rb
+++ b/lib/dicom/sequence.rb
@@ -68,7 +68,7 @@ module DICOM
     #
     # @note Two objects with the same attributes will have the same hash code.
     #
-    # @return [Fixnum] the object's hash code
+    # @return [Integer] the object's hash code
     #
     def hash
       state.hash

--- a/lib/dicom/stream.rb
+++ b/lib/dicom/stream.rb
@@ -61,7 +61,7 @@ module DICOM
     # @return [String, Integer, Float, Array] the formatted (decoded) data
     #
     def decode(length, type)
-      raise ArgumentError, "Invalid argument length. Expected Fixnum, got #{length.class}" unless length.is_a?(Fixnum)
+      raise ArgumentError, "Invalid argument length. Expected Integer, got #{length.class}" unless length.is_a?(Integer)
       raise ArgumentError, "Invalid argument type. Expected string, got #{type.class}" unless type.is_a?(String)
       value = nil
       if (@index + length) <= @string.length
@@ -127,7 +127,7 @@ module DICOM
 
     # Encodes a given value to a binary string.
     #
-    # @param [String, Integer, Float, Array] value a formatted value (String, Fixnum, etc..) or an array of numbers
+    # @param [String, Integer, Float, Array] value a formatted value (String, Integer, etc..) or an array of numbers
     # @param [String] type the type (vr) of data to encode
     # @return [String] an encoded binary string
     #
@@ -139,7 +139,7 @@ module DICOM
 
     # Encodes a value to a binary string and prepends it to the instance string.
     #
-    # @param [String, Integer, Float, Array] value a formatted value (String, Fixnum, etc..) or an array of numbers
+    # @param [String, Integer, Float, Array] value a formatted value (String, Integer, etc..) or an array of numbers
     # @param [String] type the type (vr) of data to encode
     #
     def encode_first(value, type)
@@ -149,7 +149,7 @@ module DICOM
 
     # Encodes a value to a binary string and appends it to the instance string.
     #
-    # @param [String, Integer, Float, Array] value a formatted value (String, Fixnum, etc..) or an array of numbers
+    # @param [String, Integer, Float, Array] value a formatted value (String, Integer, etc..) or an array of numbers
     # @param [String] type the type (vr) of data to encode
     #
     def encode_last(value, type)
@@ -188,7 +188,7 @@ module DICOM
     # Encodes a value, and if the the resulting binary string has an
     # odd length, appends a proper padding byte to make it even length.
     #
-    # @param [String, Integer, Float, Array] value a formatted value (String, Fixnum, etc..) or an array of numbers
+    # @param [String, Integer, Float, Array] value a formatted value (String, Integer, etc..) or an array of numbers
     # @param [String] vr the value representation of data to encode
     # @return [String] the encoded binary string
     #

--- a/spec/dicom/anonymizer_spec.rb
+++ b/spec/dicom/anonymizer_spec.rb
@@ -585,14 +585,14 @@ module DICOM
 
     context "#hash" do
 
-      it "should return the same Fixnum for two instances having the same attribute values" do
+      it "should return the same Integer for two instances having the same attribute values" do
         a1 = Anonymizer.new
         a2 = Anonymizer.new
-        expect(a1.hash).to be_a Fixnum
+        expect(a1.hash).to be_a Integer
         expect(a1.hash).to eql a2.hash
       end
 
-      it "should return a different Fixnum for two instances having different attribute values" do
+      it "should return a different Integer for two instances having different attribute values" do
         a1 = Anonymizer.new
         a2 = Anonymizer.new(:write_path => 'tmp')
         expect(a1.hash).not_to eql a2.hash

--- a/spec/dicom/d_object_spec.rb
+++ b/spec/dicom/d_object_spec.rb
@@ -273,13 +273,13 @@ module DICOM
 
     describe "#hash" do
 
-      it "should return the same Fixnum for two instances having the same attribute values" do
+      it "should return the same Integer for two instances having the same attribute values" do
         dcm1 = DObject.new
         dcm2 = DObject.new
         expect(dcm1.hash).to eql dcm2.hash
       end
 
-      it "should return a different Fixnum for two instances having different attribute values" do
+      it "should return a different Integer for two instances having different attribute values" do
         dcm1 = DObject.new
         dcm2 = DObject.new
         dcm2.add(Sequence.new('0008,0006'))

--- a/spec/dicom/element_spec.rb
+++ b/spec/dicom/element_spec.rb
@@ -444,13 +444,13 @@ module DICOM
 
     describe "#hash" do
 
-      it "should return the same Fixnum for two instances having the same attribute values" do
+      it "should return the same Integer for two instances having the same attribute values" do
         e1 = Element.new("0028,0010", 512)
         e2 = Element.new("0028,0010", 512)
         expect(e1.hash).to eql e2.hash
       end
 
-      it "should return a different Fixnum for two instances having different attribute values" do
+      it "should return a different Integer for two instances having different attribute values" do
         e1 = Element.new("0028,0010", 512)
         e2 = Element.new("0028,0010", 510)
         expect(e1.hash).not_to eql e2.hash

--- a/spec/dicom/item_spec.rb
+++ b/spec/dicom/item_spec.rb
@@ -243,13 +243,13 @@ module DICOM
 
     describe "#hash" do
 
-      it "should return the same Fixnum for two instances having the same attribute values" do
+      it "should return the same Integer for two instances having the same attribute values" do
         i1 = Item.new
         i2 = Item.new
         expect(i1.hash).to eql i2.hash
       end
 
-      it "should return a different Fixnum for two instances having different attribute values" do
+      it "should return a different Integer for two instances having different attribute values" do
         i1 = Item.new
         i2 = Item.new
         i2.add(Sequence.new("0008,0006"))

--- a/spec/dicom/sequence_spec.rb
+++ b/spec/dicom/sequence_spec.rb
@@ -195,13 +195,13 @@ module DICOM
 
     describe "#hash" do
 
-      it "should return the same Fixnum for two instances having the same attribute values" do
+      it "should return the same Integer for two instances having the same attribute values" do
         s1 = Sequence.new("0008,0006")
         s2 = Sequence.new("0008,0006")
         expect(s1.hash).to eql s2.hash
       end
 
-      it "should return a different Fixnum for two instances having different attribute values" do
+      it "should return a different Integer for two instances having different attribute values" do
         s1 = Sequence.new("0008,0006")
         s2 = Sequence.new("0008,0006")
         s2.add_item

--- a/spec/dicom/string_spec.rb
+++ b/spec/dicom/string_spec.rb
@@ -107,7 +107,7 @@ module DICOM
 
     describe "#divide" do
 
-      it "should raise ArgumentError if argument is not a Fixnum" do
+      it "should raise ArgumentError if argument is not a Integer" do
         expect {"test".divide("error")}.to raise_error(ArgumentError)
       end
 


### PR DESCRIPTION
Addresses #65 

Fixnum and Bignum have been combined into Integer class in recent versions of Ruby.  This change removes deprecated warnings.

Note:  I am getting 11 errors when running `rspec` or `rake spec`.  However these same 11 errors occur before I make any changes too.  10 of these are in regards to the logger, and 1 is about decompressing jpeg data.  Is it possible that my local environment is not set up correctly?  I tried these specs using `rvm` with ruby versions 2.2.2 and 2.4.0 and I get the same errors.

```
Failures:

  1) DICOM::DObject::parse should register one or more errors/warnings/debugs in the log when failing to successfully parse a DICOM string
     Failure/Error: DICOM.logger.expects(:warn).at_least_once

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected at least once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab9065230>.warn(any_parameters)
       satisfied expectations:
       - expected at least once, invoked once: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab9065230>.error(any_parameters)
       - expected at least once, invoked once: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab9065230>.debug(any_parameters)
     # ./spec/dicom/d_object_spec.rb:87:in `block (3 levels) in <module:DICOM>'

  2) DICOM::DObject::read should log a warning when encountering duplicate elements
     Failure/Error: DICOM.logger.expects(:warn).at_least_once

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected at least once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab8cd0688>.warn(any_parameters)
       satisfied expectations:
       - allowed any number of times, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab8cd0688>.error(any_parameters)
       - allowed any number of times, invoked once: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab8cd0688>.info(any_parameters)
       - allowed any number of times, invoked once: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab8cd0688>.debug(any_parameters)
     # ./spec/dicom/duplicate_elements_spec.rb:47:in `block (3 levels) in <module:DICOM>'

  3) With :mini_magick as image processor DICOM::ImageItem#image should log a warning when it fails to decompress compressed pixel data
     Failure/Error: DICOM.logger.expects(:warn)

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab85c5780>.warn(any_parameters)
     # ./spec/dicom/image_minimagick_spec.rb:22:in `block (4 levels) in <module:DICOM>'

  4) With :rmagick as image processor DICOM::ImageItem#image should log a warning when it fails to decompress compressed pixel data
     Failure/Error: DICOM.logger.expects(:warn)

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563ab85c5780>.warn(any_parameters)
     # ./spec/dicom/image_rmagick_spec.rb:27:in `block (4 levels) in <module:DICOM>'

  5) With :rmagick as image processor DICOM::ImageItem#images should decompress the JPEG2K encoded multiframe pixel data of this DICOM file and return the image objects in an array
     Failure/Error: expect(images.length).to eql 8

       expected: 8
            got: 0

       (compared using eql?)
     # ./spec/dicom/image_rmagick_spec.rb:147:in `block (4 levels) in <module:DICOM>'

  6) DICOM::Parent#delete should log a warning when the argument is not a string or integer
     Failure/Error: DICOM.logger.expects(:warn).once

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563abd5c2e90>.warn(any_parameters)
     # ./spec/dicom/parent_spec.rb:482:in `block (3 levels) in <module:DICOM>'

  7) DICOM::Parent#delete should log a warning when the argument is not a valid tag
     Failure/Error: DICOM.logger.expects(:warn).once

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563abd5c2e90>.warn(any_parameters)
     # ./spec/dicom/parent_spec.rb:487:in `block (3 levels) in <module:DICOM>'

  8) DICOM::Parent#delete should log a warning when the argument is a negative integer
     Failure/Error: DICOM.logger.expects(:warn).once

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563abd5c2e90>.warn(any_parameters)
     # ./spec/dicom/parent_spec.rb:492:in `block (3 levels) in <module:DICOM>'

  9) DICOM::Parent#value should log a warning when the argument is not a string or integer
     Failure/Error: DICOM.logger.expects(:warn).once

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563abd5c2e90>.warn(any_parameters)
     # ./spec/dicom/parent_spec.rb:668:in `block (3 levels) in <module:DICOM>'

  10) DICOM::Parent#value should log a warning when the argument is not a valid tag
      Failure/Error: DICOM.logger.expects(:warn).once

      Mocha::ExpectationError:
        not all expectations were satisfied
        unsatisfied expectations:
        - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563abd5c2e90>.warn(any_parameters)
      # ./spec/dicom/parent_spec.rb:673:in `block (3 levels) in <module:DICOM>'

  11) DICOM::Parent#value should log a warning when the argument is a negative integer
      Failure/Error: DICOM.logger.expects(:warn).once

      Mocha::ExpectationError:
        not all expectations were satisfied
        unsatisfied expectations:
        - expected exactly once, not yet invoked: #<DICOM::Logging::ClassMethods::ProxyLogger:0x563abd5c2e90>.warn(any_parameters)
      # ./spec/dicom/parent_spec.rb:678:in `block (3 levels) in <module:DICOM>'

Finished in 9.63 seconds (files took 1.54 seconds to load)
917 examples, 11 failures

Failed examples:

rspec ./spec/dicom/d_object_spec.rb:85 # DICOM::DObject::parse should register one or more errors/warnings/debugs in the log when failing to successfully parse a DICOM string
rspec ./spec/dicom/duplicate_elements_spec.rb:45 # DICOM::DObject::read should log a warning when encountering duplicate elements
rspec ./spec/dicom/image_minimagick_spec.rb:20 # With :mini_magick as image processor DICOM::ImageItem#image should log a warning when it fails to decompress compressed pixel data
rspec ./spec/dicom/image_rmagick_spec.rb:25 # With :rmagick as image processor DICOM::ImageItem#image should log a warning when it fails to decompress compressed pixel data
rspec ./spec/dicom/image_rmagick_spec.rb:143 # With :rmagick as image processor DICOM::ImageItem#images should decompress the JPEG2K encoded multiframe pixel data of this DICOM file and return the image objects in an array
rspec ./spec/dicom/parent_spec.rb:481 # DICOM::Parent#delete should log a warning when the argument is not a string or integer
rspec ./spec/dicom/parent_spec.rb:486 # DICOM::Parent#delete should log a warning when the argument is not a valid tag
rspec ./spec/dicom/parent_spec.rb:491 # DICOM::Parent#delete should log a warning when the argument is a negative integer
rspec ./spec/dicom/parent_spec.rb:667 # DICOM::Parent#value should log a warning when the argument is not a string or integer
rspec ./spec/dicom/parent_spec.rb:672 # DICOM::Parent#value should log a warning when the argument is not a valid tag
rspec ./spec/dicom/parent_spec.rb:677 # DICOM::Parent#value should log a warning when the argument is a negative integer
```