### PR TITLE
Improvements of encoding compatibility

### DIFF
--- a/lib/dicom/general/constants.rb
+++ b/lib/dicom/general/constants.rb
@@ -171,6 +171,7 @@ module DICOM
     'ISO_IR 13'  => 'Shift_JIS',
     'ISO 2022 IR 13' => 'Shift_JIS',
     'ISO 2022 IR 13\\ISO 2022 IR 87' => 'Shift_JIS',
+    'ISO 2022 IR 87' => 'ISO-2022-JP',
     'ISO_IR 166' => 'ISO-8859-11',
     'GB18030'    => 'GB18030',
     'ISO_IR 192' => 'UTF-8'

--- a/lib/dicom/general/constants.rb
+++ b/lib/dicom/general/constants.rb
@@ -168,7 +168,9 @@ module DICOM
     'ISO_IR 126' => 'ISO-8859-7',
     'ISO_IR 138' => 'ISO-8859-8',
     'ISO_IR 148' => 'ISO-8859-9',
-    'ISO_IR 13'  => 'JIS_X0201',
+    'ISO_IR 13'  => 'Shift_JIS',
+    'ISO 2022 IR 13' => 'Shift_JIS',
+    'ISO 2022 IR 13\\ISO 2022 IR 87' => 'Shift_JIS',
     'ISO_IR 166' => 'ISO-8859-11',
     'GB18030'    => 'GB18030',
     'ISO_IR 192' => 'UTF-8'


### PR DESCRIPTION
# Summary

This pull request improves the compatibility with some Japanese encoding.

# Problem

ruby-dicom 0.9.7 can't read dicom headers created by old dicom modality in Japan because these modalities specify character encoding 'ISO 2022 IR 13', 'ISO 2022 IR 13\ISO 2022 IR 87'.

# Solution

Ruby can't read entire these encoding but part of these with encoding 'Shift_JIS'. So, this pull request proposes the new DICOM::ENCODING_NAME hash.