### PR TITLE
add CI by GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.2']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install ImageMagick
+      run: sudo apt-get update && sudo apt-get install -y imagemagick libmagickwand-dev
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rspec


### PR DESCRIPTION
I think ruby-dicom is a useful gem. I thought it would be good if it was compatible with Ruby3. However, although there is test code, there is no CI. I added CI using GitHub Actions to make it easier to check the impact of changes.

GitHub Actions can be used for free in the Public Repository. https://docs.github.com/ja/billing/managing-billing-for-your-products/about-billing-for-github-actions

I used setup-ruby to set up the Ruby environment in GitHub Actions. I tried to set up the environment with Ruby1.9.3 according to [REQUIREMENTS](https://github.com/dicom/ruby-dicom/blob/master/README.md?plain=1#L18), but gave up and decided to use Ruby2.2 as described in [gemspec](https://github.com/dicom/ruby-dicom/blob/master/dicom.gemspec#L20).

[Here are the test results](https://github.com/hokkai7go/ruby-dicom/actions/runs/16099301714/job/45426314911).

I don't have the results to show how many specs were failing before this work. Please let me know if there are any changes that need to be made.